### PR TITLE
Add lerna.json to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 dist/
 coverage/
+lerna.json


### PR DESCRIPTION
Makes CI not fail in master after release when `lerna publish` changes
the file's formatting.
