### PR TITLE
Make `lerna release` not leave `gitHead`s to package.json files

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
         id: publish
         run: |
           echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}' > .npmrc
-          yarn publish:all ${{ github.event.inputs.release-type }}
+          yarn release ${{ github.event.inputs.release-type }}
           echo "::set-output name=version::$(node --print 'require("./lerna.json").version')"
 
       - name: "Update the changelog"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "lerna run build",
     "clean": "lerna run clean",
-    "publish:all": "lerna publish --force-publish='*' --exact --no-git-tag-version --no-git-reset --no-verify-access --yes",
+    "release": "lerna publish --force-publish='*' --exact --no-git-tag-version --no-git-reset --no-verify-access --yes",
     "format": "prettier --write '**/*.{ts,js,json}' && eslint --fix --max-warnings=0 --ext=.ts,.js .",
     "lint": "prettier --check '**/*.{ts,js,json}' && eslint --max-warnings=0 --ext=.ts,.js .",
     "type-check": "yarn tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "lerna run build",
     "clean": "lerna run clean",
-    "release": "lerna publish --force-publish='*' --exact --no-git-tag-version --no-git-reset --no-verify-access --yes",
+    "clean:git-head": "lerna exec node \\$LERNA_ROOT_PATH/scripts/clean-git-head.js",
+    "release": "lerna publish --force-publish='*' --exact --no-git-tag-version --no-git-reset --no-verify-access --yes && yarn clean:git-head",
     "format": "prettier --write '**/*.{ts,js,json}' && eslint --fix --max-warnings=0 --ext=.ts,.js .",
     "lint": "prettier --check '**/*.{ts,js,json}' && eslint --max-warnings=0 --ext=.ts,.js .",
     "type-check": "yarn tsc --noEmit",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,5 @@
   },
   "engines": {
     "node": ">=12.0.0"
-  },
-  "gitHead": "d83199fe1aaa931a7dcf4c12f6f67ef0083cbecc"
+  }
 }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -39,6 +39,5 @@
   },
   "engines": {
     "node": ">=12.0.0"
-  },
-  "gitHead": "d83199fe1aaa931a7dcf4c12f6f67ef0083cbecc"
+  }
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -39,6 +39,5 @@
   },
   "engines": {
     "node": ">=12.0.0"
-  },
-  "gitHead": "d83199fe1aaa931a7dcf4c12f6f67ef0083cbecc"
+  }
 }

--- a/scripts/clean-git-head.js
+++ b/scripts/clean-git-head.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const packageJsonPath = path.resolve('./package.json');
+
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
+
+delete packageJson.gitHead;
+
+fs.writeFileSync(
+  packageJsonPath,
+  JSON.stringify(packageJson, undefined, 2) + '\n',
+);


### PR DESCRIPTION
These should not be committed to VCS and they would normally get removed
if we wouldn't use `--no-git-reset` with `lerna publish`.
