### PR TITLE
Send memory usage information together with metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Send current system CPU usage together with metrics.
+- Send current system memory usage and total available memory together with metrics.
 
 ## [1.3.0] - 2022-02-02
 

--- a/packages/express/__tests__/index.test.ts
+++ b/packages/express/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import https from 'https';
 import type http from 'http';
 
@@ -28,11 +29,15 @@ describe('apilyticsMiddleware()', () => {
 
   beforeEach(() => {
     jest.useFakeTimers('legacy');
+
     requestSpy = jest
       .spyOn(https, 'request')
       .mockImplementation(
         () => clientRequestMock as unknown as http.ClientRequest,
       );
+
+    // @ts-ignore
+    jest.spyOn(fs.promises, 'readFile').mockImplementation(fs.readFileSync);
   });
 
   afterEach(() => {
@@ -112,6 +117,8 @@ describe('apilyticsMiddleware()', () => {
       statusCode: 200,
       responseSize: 2,
       cpuUsage: expect.any(Number),
+      memoryUsage: expect.any(Number),
+      memoryTotal: expect.any(Number),
       timeMillis: expect.any(Number),
     });
     expect(data['timeMillis']).toEqual(Math.trunc(data['timeMillis']));
@@ -152,6 +159,8 @@ describe('apilyticsMiddleware()', () => {
       requestSize: 0,
       responseSize: 7,
       cpuUsage: expect.any(Number),
+      memoryUsage: expect.any(Number),
+      memoryTotal: expect.any(Number),
       timeMillis: expect.any(Number),
     });
   });
@@ -222,6 +231,8 @@ describe('apilyticsMiddleware()', () => {
       statusCode: 500,
       responseSize: expect.any(Number),
       cpuUsage: expect.any(Number),
+      memoryUsage: expect.any(Number),
+      memoryTotal: expect.any(Number),
       timeMillis: expect.any(Number),
     });
   });

--- a/packages/next/__tests__/index.test.ts
+++ b/packages/next/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import http from 'http';
 import https from 'https';
 
@@ -28,11 +29,15 @@ describe('withApilytics()', () => {
 
   beforeEach(() => {
     jest.useFakeTimers('legacy');
+
     requestSpy = jest
       .spyOn(https, 'request')
       .mockImplementation(
         () => clientRequestMock as unknown as http.ClientRequest,
       );
+
+    // @ts-ignore
+    jest.spyOn(fs.promises, 'readFile').mockImplementation(fs.readFileSync);
   });
 
   afterEach(() => {
@@ -132,6 +137,8 @@ describe('withApilytics()', () => {
       statusCode: 200,
       responseSize: 2,
       cpuUsage: expect.any(Number),
+      memoryUsage: expect.any(Number),
+      memoryTotal: expect.any(Number),
       timeMillis: expect.any(Number),
     });
     expect(data['timeMillis']).toEqual(Math.trunc(data['timeMillis']));
@@ -172,6 +179,8 @@ describe('withApilytics()', () => {
       requestSize: 0,
       responseSize: 7,
       cpuUsage: expect.any(Number),
+      memoryUsage: expect.any(Number),
+      memoryTotal: expect.any(Number),
       timeMillis: expect.any(Number),
     });
   });
@@ -241,6 +250,8 @@ describe('withApilytics()', () => {
       method: 'GET',
       responseSize: 0,
       cpuUsage: expect.any(Number),
+      memoryUsage: expect.any(Number),
+      memoryTotal: expect.any(Number),
       timeMillis: expect.any(Number),
     });
   });
@@ -259,6 +270,8 @@ describe('withApilytics()', () => {
       statusCode: 200,
       responseSize: 0,
       cpuUsage: expect.any(Number),
+      memoryUsage: expect.any(Number),
+      memoryTotal: expect.any(Number),
       timeMillis: expect.any(Number),
     });
   });


### PR DESCRIPTION
We special case Linux since getting accurate memory usage values on it
is most important. On macOS the memory value returned by `os.freemem()`
is also inaccurate for similar reasons than on Linux, but it would be
quite rare rare to find it as a production web server's OS. Not sure how
accurate `os.freemem()` is on other platforms that Node.js supports
either, but should be better than nothing.

Good to note that `MemAvailable` in `/proc/meminfo` is only available on
Linux kernel 3.14 and up, but since 3.14 has already reached end of
life we can pretty safely ignore support for systems before it.