### PR TITLE
Use bash as the shell for CI tests job on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
       matrix:
         node-version: ['12', '14', '16', '17']
         os: [ubuntu-latest, macos-latest, windows-latest]
-
+    defaults:
+      run:
+        shell: bash
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
Allows us to not worry about the shell compatibility of our npm scripts
or CI steps.
