### PR TITLE
Send user's IP address with metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Send user's IP address with metrics. Used for visualization aggregate geolocation data.
+  The IP is never stored, and it is never sent to 3rd parties.
+
 ## [1.4.1] - 2022-02-20
 
 ### Added

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -44,6 +44,7 @@ const myApilyticsMiddleware = async (req, handler) => {
 
   const timer = milliSecondTimer();
   const res = await handler(req);
+
   sendApilyticsMetrics({
     apiKey,
     path: req.path,
@@ -53,6 +54,7 @@ const myApilyticsMiddleware = async (req, handler) => {
     requestSize: req.bodyBytes.length,
     responseSize: res.bodyBytes.length,
     userAgent: req.headers['user-agent'],
+    ip: req.headers['x-forwarded-for']?.split(',')[0].trim(),
     timeMillis: timer(),
   });
   return res;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ interface Params {
   requestSize?: number;
   responseSize?: number;
   userAgent?: string;
+  ip?: string;
   apilyticsIntegration?: string;
   integratedLibrary?: string;
 }
@@ -38,6 +39,8 @@ interface Params {
  * @param params.responseSize - Size of the sent HTTP response's body in bytes.
  * @param params.userAgent - Value of the `User-Agent` header from the user's
  *     HTTP request.
+ * @param params.ip - User's IP address (used for geolocation,
+ *     never stored nor sent to 3rd parties).
  * @param params.apilyticsIntegration - Name of the Apilytics integration that's
  *     calling this, e.g. 'apilytics-node-express'.
  *     No need to pass this when calling from user code.
@@ -49,6 +52,7 @@ interface Params {
  *
  *     const timer = milliSecondTimer();
  *     const res = await handler(req);
+ *
  *     sendApilyticsMetrics({
  *       apikey: "<your-api-key>",
  *       path: req.path,
@@ -58,6 +62,7 @@ interface Params {
  *       requestSize: req.bodyBytes.length,
  *       responseSize: res.bodyBytes.length,
  *       userAgent: req.headers['user-agent'],
+ *       ip: req.headers['x-forwarded-for']?.split(',')[0].trim(),
  *       timeMillis: timer(),
  *     });
  */
@@ -71,6 +76,7 @@ export const sendApilyticsMetrics = ({
   requestSize,
   responseSize,
   userAgent,
+  ip,
   apilyticsIntegration,
   integratedLibrary,
 }: Params): void => {
@@ -86,6 +92,7 @@ export const sendApilyticsMetrics = ({
         requestSize,
         responseSize,
         userAgent: userAgent || undefined,
+        ip: ip || undefined,
         cpuUsage,
         memoryUsage,
         memoryTotal,

--- a/packages/express/__tests__/index.test.ts
+++ b/packages/express/__tests__/index.test.ts
@@ -178,6 +178,31 @@ describe('apilyticsMiddleware()', () => {
     expect(data.userAgent).toEqual('some agent');
   });
 
+  it('should send IP', async () => {
+    const agent = createAgent({ apiKey });
+    let response = await agent
+      .get('/dummy')
+      .set('X-Forwarded-For', '127.0.0.1');
+    expect(response.status).toEqual(200);
+
+    await flushTimers();
+
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    let data = JSON.parse(clientRequestMock.write.mock.calls[0]);
+    expect(data.ip).toEqual('127.0.0.1');
+
+    response = await agent
+      .get('/dummy')
+      .set('X-Forwarded-For', '127.0.0.2,127.0.0.3');
+    expect(response.status).toEqual(200);
+
+    await flushTimers();
+
+    expect(requestSpy).toHaveBeenCalledTimes(2);
+    data = JSON.parse(clientRequestMock.write.mock.calls[1]);
+    expect(data.ip).toEqual('127.0.0.2');
+  });
+
   it('should handle zero request and response sizes', async () => {
     const agent = createAgent({ apiKey });
     const response = await agent.post('/empty');

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -59,6 +59,10 @@ export const apilyticsMiddleware = (
         requestSize,
         responseSize,
         userAgent: req.headers['user-agent'],
+        // Type assertion since the value cannot be an array.
+        ip: (req.headers['x-forwarded-for'] as string | undefined)
+          ?.split(',')[0]
+          .trim(),
         timeMillis: timer(),
         apilyticsIntegration: 'apilytics-node-express',
         integratedLibrary: EXPRESS_VERSION

--- a/packages/next/__tests__/index.test.ts
+++ b/packages/next/__tests__/index.test.ts
@@ -198,6 +198,31 @@ describe('withApilytics()', () => {
     expect(data.userAgent).toEqual('some agent');
   });
 
+  it('should send IP', async () => {
+    const agent = createAgent({ apiKey });
+    let response = await agent
+      .get('/dummy')
+      .set('X-Forwarded-For', '127.0.0.1');
+    expect(response.status).toEqual(200);
+
+    await flushTimers();
+
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    let data = JSON.parse(clientRequestMock.write.mock.calls[0]);
+    expect(data.ip).toEqual('127.0.0.1');
+
+    response = await agent
+      .get('/dummy')
+      .set('X-Forwarded-For', '127.0.0.2,127.0.0.3');
+    expect(response.status).toEqual(200);
+
+    await flushTimers();
+
+    expect(requestSpy).toHaveBeenCalledTimes(2);
+    data = JSON.parse(clientRequestMock.write.mock.calls[1]);
+    expect(data.ip).toEqual('127.0.0.2');
+  });
+
   it('should handle zero request and response sizes', async () => {
     const agent = createAgent({ apiKey });
     const response = await agent.post('/empty');

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -74,6 +74,10 @@ export const withApilytics = <T>(
         requestSize,
         responseSize,
         userAgent: req.headers['user-agent'],
+        // Type assertion since the value cannot be an array.
+        ip: (req.headers['x-forwarded-for'] as string | undefined)
+          ?.split(',')[0]
+          .trim(),
         timeMillis: timer(),
         apilyticsIntegration: 'apilytics-node-next',
         integratedLibrary: NEXT_VERSION ? `next/${NEXT_VERSION}` : undefined,


### PR DESCRIPTION
Used for visualization aggregate geolocation data. The IP is never
stored, and it is never sent to 3rd parties.

We read the IP from the `X-Forwarded-For` header since in production
one's backend service is most likely behind a reverse proxy of some
sort. We use the left-most value in case there are multiple IPs in it,
since that's most likely not from "our" infra and we don't have to worry
about spoofing too much because it's not used for anything security
related.

Some additional reading about getting the real IP address:
https://adam-p.ca/blog/2022/03/x-forwarded-for/